### PR TITLE
Docs: adiciona manual e rodadas da colaboracao com Codex

### DIFF
--- a/docs/planejamento/rodadas/RODADA_20260322_01.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_01.md
@@ -1,0 +1,232 @@
+# Rodada 01 - Alinhamento Inicial de Contexto
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Primeira rodada estruturada de colaboracao entre Thiago e Codex no projeto ShowTrials.
+O objetivo foi construir entendimento profundo do contexto antes de iniciar execucao tecnica da nova fase arquitetural.
+
+## Objetivo da Rodada
+
+Consolidar o contexto do projeto a partir de:
+
+- documentacao historica e arquitetural
+- fluxos de governanca e qualidade
+- estado atual do codigo
+- estado operacional de Git e GitHub
+
+## Tipo de Rodada
+
+- `leitura`
+- `diagnostico`
+- `planejamento`
+
+## Inputs Analisados
+
+### Documentacao base
+
+- `docs/index.md`
+- `docs/overview.md`
+- `docs/ARCHITECTURE.md`
+- `README.md`
+
+### Fases do projeto
+
+- `docs/fases/FASE1_DOMAIN.md`
+- `docs/fases/FASE2_APPLICATION.md`
+- `docs/fases/FASE3_INFRASTRUCTURE.md`
+- `docs/fases/FASE4_CLI.md`
+- `docs/fases/FASE5_TRADUCAO.md`
+- `docs/fases/FASE6_EXPORTACAO.md`
+- `docs/fases/FASE7_RELATORIOS.md`
+- `docs/fases/FASE8_ANALISE_TEXTO.md`
+- `docs/fases/FASE9_WEB_INTERFACE.md`
+- `docs/fases/FASE10_SERVICE_REGISTRY.md`
+- `docs/fases/FASE11_CI.md`
+- `docs/fases/FASE12.md`
+- `docs/fases/FASE13.md`
+- `docs/fases/FASE14.md`
+- `docs/fases/FASE15.md`
+- `docs/fases/FASE16.md`
+- `docs/fases/FASE17.md`
+
+### Projeto e direcao arquitetural
+
+- `docs/projeto/visao_do_projeto.md`
+- `docs/projeto/roadmap_arquitetural.md`
+- `docs/projeto/analise_arquitetural.md`
+- `docs/projeto/direcionamento_arquitetural_engine_mvp.md`
+- `docs/projeto/manual_gestao.md`
+- `docs/projeto/questionario_levantamento_requisitos.md`
+
+### Fluxos e governanca
+
+- `docs/flows/GOVERNANCA.md`
+- `docs/flows/git_flow.md`
+- `docs/flows/quality_flow.md`
+- `docs/flows/code_review_flow.md`
+- `docs/flows/refactoring_flow.md`
+- `docs/flows/documentation_flow.md`
+- `docs/flows/dependencies_flow.md`
+- `docs/flows/telemetry_flow.md`
+- `docs/flows/debug_flow.md`
+- `docs/flows/emergency_flow.md`
+- `docs/flows/fluxo_projects_github_cli.md`
+
+### Codigo inspecionado
+
+- `src/domain/entities/documento.py`
+- `src/application/use_cases/base.py`
+- `src/application/use_cases/traduzir_documento.py`
+- `src/application/use_cases/analisar_acervo.py`
+- `src/infrastructure/factories.py`
+- `src/infrastructure/registry.py`
+- `src/infrastructure/persistence/sqlite_repository.py`
+- `src/interface/cli/app.py`
+- `src/interface/web/app.py`
+- `run.py`
+- `pyproject.toml`
+- `config.yaml`
+
+### Estado Git/GitHub analisado
+
+- `git status --short`
+- `git branch --show-current`
+- `git log --oneline --decorate -10`
+- `git branch`
+- `gh issue list --state open --limit 30`
+- `gh issue list --state open --json number,title,labels,milestone`
+- `gh pr list --state all --limit 20`
+- `gh pr view 18 --comments`
+- `gh label list`
+- `gh project list --owner rib-thiago`
+- `gh project item-list 1 --owner rib-thiago`
+- `gh project field-list 1 --owner rib-thiago --format json`
+- `gh api repos/rib-thiago/showtrials-tcc/milestones`
+- `gh issue view 6 --comments`
+
+## Estado Encontrado
+
+### Produto e arquitetura
+
+O sistema atual e uma aplicacao documento-centrica, especializada no acervo ShowTrials, com:
+
+- Clean Architecture
+- CLI e Web
+- traducao
+- exportacao
+- relatorios
+- NLP
+- service registry
+
+### Direcao futura
+
+A direcao arquitetural definida em 2026 e evoluir de aplicacao especifica para plataforma de pipeline configuravel com:
+
+- contexto de execucao
+- plugins por papel
+- YAML/JSON declarativo
+- persistencia via sink
+- versionamento simples de pipeline
+
+### Estado do codigo
+
+O codigo ainda representa majoritariamente o sistema ShowTrials original.
+A engine de pipeline ainda nao foi implementada.
+Ja existem sementes de extensibilidade, especialmente via `ServiceRegistry` e configuracao YAML.
+
+### Estado Git
+
+- branch atual: `main`
+- `main` alinhada com `origin/main`
+- working tree suja com banco alterado e artefatos locais de diagnostico/coleta
+
+### Estado GitHub
+
+- milestone ativa: `MVP - Engine de Pipeline`
+- 13 issues abertas
+- 1 PR aberto: `#18`
+- labels aderentes a governanca
+- project existente, mas com nome generico
+
+### Estado do board
+
+- o project contem itens historicos e itens atuais
+- a issue `#6` esta em `In review`
+- o PR `#18` aparece em `Backlog`
+- ainda ha incoerencias operacionais entre status de issue e PR
+
+## Inferencias e Leitura do Codex
+
+- O projeto possui visao estrategica clara e documentada.
+- A documentacao funciona como mecanismo normativo, nao apenas descritivo.
+- A fase atual ideal nao e "implementar a engine imediatamente", mas alinhar operacao e foco antes.
+- O PR `#18` parece ser o principal trabalho pendente de infraestrutura antes de abrir nova frente estrutural.
+- A governanca do projeto esta mais madura do que a operacao cotidiana atual.
+
+## Decisoes Tomadas
+
+- Antes de "por a mao na massa", consolidar entendimento total do contexto.
+- Tratar a documentacao de colaboracao com o Codex como parte do sistema de trabalho do projeto.
+- Criar um manual formal de colaboracao com o Codex.
+- Adotar documentos de rodada para registrar cada ciclo relevante de trabalho do Codex.
+
+## Acoes Executadas
+
+- leitura ampla da documentacao do projeto
+- leitura de arquivos centrais do codigo
+- consolidacao do estado de Git e GitHub
+- diagnostico de alinhamento entre arquitetura, governanca e operacao
+- criacao do manual `manual_colaboracao_codex.md`
+
+## Arquivos Afetados
+
+### Criados nesta rodada
+
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md`
+
+### Arquivos inspecionados de forma relevante
+
+- conjunto amplo de `docs/`
+- arquivos centrais de `src/`
+- `pyproject.toml`
+- `config.yaml`
+
+## Git e GitHub
+
+- branch atual observada: `main`
+- milestone ativa: `MVP - Engine de Pipeline`
+- issue em foco operacional identificada: `#6`
+- PR aberto relevante: `#18`
+- issues estruturais principais: `#10` a `#17`
+- project: `@rib-thiago's untitled project`
+
+## Riscos e Pendencias
+
+- working tree local nao esta higienizada para execucao formal por issue/branch
+- o board ainda mistura itens historicos com backlog atual
+- issue `#1` esta na milestone ativa mesmo sendo `P2`
+- issue `#6` esta em `In review`, enquanto o PR correspondente esta em `Backlog`
+- o nome do project nao reflete o estado atual de governanca
+
+## Proximo Passo Recomendado
+
+Executar uma pequena fase de alinhamento operacional antes da primeira issue da engine:
+
+1. revisar o PR `#18`
+2. decidir merge, ajuste ou fechamento da issue `#6`
+3. limpar incoerencias do board
+4. confirmar qual sera a primeira issue estrutural da engine
+
+## Observacoes de Governanca
+
+- a milestone ativa esta correta e coerente com a visao futura
+- as issues da engine respeitam bem a governanca
+- ha aderencia conceitual forte entre docs e backlog
+- ha pequenos desvios operacionais em branch atual e status do board
+- nenhum trabalho estrutural da engine foi iniciado nesta rodada

--- a/docs/planejamento/rodadas/RODADA_20260322_02.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_02.md
@@ -1,0 +1,144 @@
+# Rodada 02 - Diagnostico de Alinhamento Operacional
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Depois da criacao do manual de colaboracao e da primeira rodada de alinhamento geral, surgiu a necessidade de decidir por que ainda nao foi feito commit e como enquadrar corretamente o estado atual do repositorio antes de iniciar trabalho formal de issue/branch/PR.
+
+## Objetivo da Rodada
+
+Diagnosticar o estado operacional atual do projeto em relacao a:
+
+- working tree local
+- aderencia ao Git Flow e a governanca
+- enquadramento dos novos documentos criados
+- sequencia segura antes do primeiro commit desta nova fase
+
+## Tipo de Rodada
+
+- `diagnostico`
+- `planejamento`
+
+## Inputs Analisados
+
+- `git status --short`
+- `git diff --name-only`
+- `git ls-files --others --exclude-standard docs/projeto/manual_colaboracao_codex.md docs/planejamento/rodadas/TEMPLATE_RODADA.md docs/planejamento/rodadas/RODADA_20260322_01.md`
+- `docs/flows/git_flow.md`
+- `docs/flows/GOVERNANCA.md`
+- `docs/flows/documentation_flow.md`
+
+## Estado Encontrado
+
+### Working tree
+
+O estado atual da arvore local esta dividido em tres grupos:
+
+1. **Mudanca rastreada em arquivo versionado**
+   - `data/showtrials.db`
+
+2. **Arquivos e pastas novas locais de apoio ou diagnostico**
+   - `coletar_info_faltante.sh`
+   - `coletar_info_projeto.sh`
+   - `coletores/`
+   - `diagnostico_20260302_233956*`
+   - `diagnostico_fix_20260302_234244*`
+   - `upload_crafttext/`
+   - `git`
+   - `gitgraph`
+
+3. **Arquivos documentais criados nesta colaboracao**
+   - `docs/projeto/manual_colaboracao_codex.md`
+   - `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+   - `docs/planejamento/rodadas/RODADA_20260322_01.md`
+
+### Estado dos arquivos criados nesta colaboracao
+
+Os tres arquivos documentais criados nesta fase:
+
+- ainda nao estao versionados
+- nao alteram nenhum arquivo existente
+- estao isolados como novos arquivos
+
+### Estado de alteracoes rastreadas
+
+A unica alteracao em arquivo ja versionado e:
+
+- `data/showtrials.db`
+
+Isso significa que, neste momento, nao existe mistura entre:
+
+- documentacao nova criada para o metodo de colaboracao
+- alteracoes em codigo ou docs ja existentes
+
+## Inferencias e Leitura do Codex
+
+- O motivo para nao commitar agora e valido do ponto de vista do processo.
+- A situacao atual nao e de "trabalho pronto para commit", e sim de "repositorio ainda nao enquadrado".
+- O principal obstaculo para um commit limpo nao sao os arquivos de documentacao criados, mas o estado geral da `main` e os artefatos locais coexistindo no working tree.
+- Como os novos documentos estao isolados, eles poderao ser facilmente carregados para uma branch propria quando a fase operacional for concluida.
+
+## Decisoes Tomadas
+
+- Nao fazer commit imediato.
+- Tratar o momento atual como fase de alinhamento operacional.
+- Separar conceitualmente:
+  - material local de apoio/diagnostico
+  - banco alterado localmente
+  - documentacao nova do metodo de colaboracao
+- Adiar a criacao de branch e commit ate definirmos o enquadramento correto dentro do fluxo oficial.
+
+## Acoes Executadas
+
+- diagnostico do estado do working tree
+- verificacao de quais arquivos novos pertencem a esta colaboracao
+- verificacao de qual arquivo versionado esta de fato modificado
+- cruzamento com `git_flow.md`, `GOVERNANCA.md` e `documentation_flow.md`
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_02.md`
+
+### Arquivos analisados
+
+- `docs/flows/git_flow.md`
+- `docs/flows/GOVERNANCA.md`
+- `docs/flows/documentation_flow.md`
+
+## Git e GitHub
+
+- branch atual observada: `main`
+- desvio em relacao ao fluxo: trabalho em `main` com working tree suja
+- novo material documental ainda sem branch dedicada
+- nenhum commit realizado nesta rodada
+
+## Riscos e Pendencias
+
+- `main` permanece com estado local misto entre trabalho valido e artefatos auxiliares
+- `data/showtrials.db` e uma alteracao rastreada que pode contaminar qualquer commit futuro se nao for tratada conscientemente
+- ainda nao foi decidido se a documentacao nova entra em issue existente ou demanda issue propria
+- ainda nao foi executada a revisao operacional do PR `#18`
+
+## Proximo Passo Recomendado
+
+Executar uma rodada curta de enquadramento operacional com foco em decisao, nao em codigo:
+
+1. classificar os itens locais em:
+   - manter local
+   - versionar depois
+   - ignorar ou remover do fluxo de commit
+2. decidir se os documentos desta colaboracao entram em branch `docs/...` propria
+3. revisar o PR `#18` antes de iniciar a primeira issue estrutural da engine
+4. so depois disso criar branch nova e preparar commit limpo
+
+## Observacoes de Governanca
+
+- o `git_flow.md` diz explicitamente para nao trabalhar diretamente na `main`
+- a governanca exige rastreabilidade por issue e branch
+- portanto, segurar o commit neste momento foi uma decisao correta
+- a rodada confirma que o alinhamento operacional deve preceder qualquer movimento formal de versionamento desta nova fase

--- a/docs/planejamento/rodadas/RODADA_20260322_03.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_03.md
@@ -1,0 +1,146 @@
+# Rodada 03 - Triagem do Working Tree e Precedencia Operacional
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Depois de confirmar que o commit nao deveria acontecer imediatamente, foi necessario transformar essa percepcao em uma triagem operacional concreta: o que no working tree atual pertence ao fluxo formal do projeto, o que e apenas material local e qual deve ser a precedencia entre organizacao local e o PR pendente da milestone.
+
+## Objetivo da Rodada
+
+Classificar o working tree atual e propor uma sequencia segura para:
+
+- nao contaminar commits futuros
+- preservar os documentos novos criados nesta colaboracao
+- respeitar o Git Flow e a governanca
+- decidir a precedencia operacional antes da primeira branch formal desta nova fase
+
+## Tipo de Rodada
+
+- `diagnostico`
+- `planejamento`
+
+## Inputs Analisados
+
+- `git status --short`
+- `.gitignore`
+- `git check-ignore -v ...`
+- `gh pr view 18 --comments` (coletado anteriormente)
+- tentativa de `gh pr view 18 --json ...` nesta rodada
+
+## Estado Encontrado
+
+### Grupo 1 - Material documental novo e limpo
+
+Arquivos criados nesta colaboracao:
+
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md`
+- `docs/planejamento/rodadas/RODADA_20260322_02.md`
+
+Esses arquivos:
+
+- estao isolados
+- nao alteram arquivos existentes
+- sao bons candidatos a branch documental propria
+
+### Grupo 2 - Alteracao rastreada sensivel
+
+- `data/showtrials.db`
+
+Como e arquivo versionado e alterado, ele representa o maior risco de contaminar um commit documental ou operacional.
+
+### Grupo 3 - Material local auxiliar / diagnostico / exploracao
+
+- `coletar_info_faltante.sh`
+- `coletar_info_projeto.sh`
+- `coletores/`
+- `diagnostico_20260302_233956.tar.gz`
+- `diagnostico_20260302_233956/`
+- `diagnostico_fix_20260302_234244.tar.gz`
+- `diagnostico_fix_20260302_234244/`
+- `upload_crafttext/`
+- `git`
+- `gitgraph`
+
+Esses itens nao estao cobertos pelo `.gitignore` atual.
+
+### .gitignore atual
+
+O `.gitignore` ja cobre:
+
+- artefatos como `exportados/`, `relatorios/`, `analises/`
+- `legacy/`
+- `*.db`
+- `coverage.xml`
+- `/site/`
+
+Mas nao cobre explicitamente os artefatos locais listados acima.
+
+## Inferencias e Leitura do Codex
+
+- O problema operacional agora nao e falta de branch apenas; e falta de triagem do working tree.
+- Os documentos novos criados nesta colaboracao estao em excelente estado para versionamento futuro.
+- O item que mais exige disciplina e `data/showtrials.db`, porque qualquer commit em `main` ou branch nova pode capturá-lo sem querer.
+- Os artefatos locais atuais parecem mais proximos de material de apoio e diagnostico do que de entregavel pronto para o repositório.
+- A melhor sequencia nao e "limpar tudo primeiro" nem "commitar docs agora", mas decidir conscientemente o destino de cada grupo.
+
+## Decisoes Tomadas
+
+- Tratar o working tree por grupos, e nao como um bloco unico.
+- Preservar os documentos novos como candidatos a branch documental dedicada.
+- Nao misturar `data/showtrials.db` com commit de documentacao.
+- Considerar os artefatos de diagnostico/coleta como material local ate classificacao formal.
+- Manter o PR `#18` como item de alta precedencia operacional por estar ligado a issue `#6` da milestone ativa.
+
+## Acoes Executadas
+
+- leitura do `.gitignore`
+- verificacao de cobertura de ignore para os artefatos locais
+- classificacao do working tree por destino operacional
+- verificacao complementar da situacao do PR `#18`
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_03.md`
+
+### Arquivos analisados
+
+- `.gitignore`
+
+## Git e GitHub
+
+- branch atual observada: `main`
+- PR relevante em aberto: `#18`
+- issue operacional relevante: `#6`
+- observacao tecnica: tentativa de consultar o PR por JSON falhou nesta rodada por indisponibilidade de conexao com a API do GitHub
+
+## Riscos e Pendencias
+
+- risco de commit acidental de `data/showtrials.db`
+- risco de arrastar material local de diagnostico para uma branch formal
+- falta de regra explicita de ignore para alguns artefatos auxiliares
+- pendencia de decisao sobre se os novos docs entram antes ou depois da resolucao do PR `#18`
+
+## Proximo Passo Recomendado
+
+Adotar a seguinte ordem operacional:
+
+1. **Nao commitar nada ainda**
+2. **Definir destino dos grupos**
+   - docs novos: candidatos a branch `docs/...`
+   - `data/showtrials.db`: manter fora de qualquer commit documental
+   - artefatos auxiliares: manter locais ate classificacao posterior
+3. **Revisar e decidir o PR `#18`**
+4. **Depois criar a primeira branch formal da nova fase**
+
+## Observacoes de Governanca
+
+- a governanca e o Git Flow justificam plenamente nao commitar direto da `main`
+- a triagem confirma que o alinhamento operacional e etapa legitima, nao atraso indevido
+- a precedencia do PR `#18` faz sentido porque ele ja esta dentro da milestone ativa e em estado avancado de revisao

--- a/docs/planejamento/rodadas/RODADA_20260322_04.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_04.md
@@ -1,0 +1,136 @@
+# Rodada 04 - Classificacao dos Materiais Locais Soltos
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Depois da triagem inicial do working tree, foi necessario classificar melhor os materiais locais fora do fluxo formal do projeto. O usuario esclareceu a origem e a intencao de parte desses itens, permitindo separar descarte, registro historico e prototipacao real.
+
+## Objetivo da Rodada
+
+Definir uma recomendacao de destino para os materiais locais soltos, com foco em:
+
+- preservar o que ainda tem valor para o projeto
+- descartar o que e apenas diagnostico descartavel
+- evitar perda de contexto util
+- preparar o repositorio para o fluxo formal futuro
+
+## Tipo de Rodada
+
+- `diagnostico`
+- `planejamento`
+
+## Inputs Analisados
+
+### Estado local previamente identificado
+
+- `upload_crafttext/`
+- `diagnostico_20260302_233956/`
+- `diagnostico_20260302_233956.tar.gz`
+- `diagnostico_fix_20260302_234244/`
+- `diagnostico_fix_20260302_234244.tar.gz`
+- `coletar_info_faltante.sh`
+- `coletar_info_projeto.sh`
+- `git`
+- `gitgraph`
+- `coletores/`
+- `data/showtrials.db`
+
+### Esclarecimentos do usuario
+
+- `upload_crafttext/` parece ser material antigo de teste com chatbots de IA
+- `diagnostico_*` e `*.tar.gz` sao produtos dos scripts bash de diagnostico
+- `git` e `gitgraph` tambem sao diagnosticos
+- `coletores/` e prototipacao real de raspagem para multiplas fontes e deve ser preservado
+- a mudanca em `data/showtrials.db` decorre de uso de `coletores/`
+
+## Estado Encontrado
+
+### Grupo A - Diagnosticos descartaveis
+
+Itens explicitamente caracterizados como produtos de diagnostico e experimentacao auxiliar:
+
+- `upload_crafttext/`
+- `diagnostico_20260302_233956/`
+- `diagnostico_20260302_233956.tar.gz`
+- `diagnostico_fix_20260302_234244/`
+- `diagnostico_fix_20260302_234244.tar.gz`
+- `git`
+- `gitgraph`
+
+### Grupo B - Ferramentas geradoras de diagnostico
+
+- `coletar_info_faltante.sh`
+- `coletar_info_projeto.sh`
+
+Esses arquivos podem ter dois destinos plausiveis:
+
+- manter como scripts utilitarios do projeto
+- remover se forem apenas ferramentas ad hoc de uma fase ja encerrada
+
+### Grupo C - Prototipacao real que deve ser preservada
+
+- `coletores/`
+
+Este diretorio nao e mais apenas "lixo local". Ele representa exploracao funcional real, ainda sem issue e sem enquadramento formal, mas com potencial concreto de evolucao futura.
+
+### Grupo D - Dado alterado em banco versionado
+
+- `data/showtrials.db`
+
+A alteracao no banco decorre da experimentacao realizada em `coletores/`.
+
+## Inferencias e Leitura do Codex
+
+- Nem todo material fora do fluxo formal precisa ser salvo no repositório.
+- O maior valor duradouro parece estar em `coletores/`, nao nos snapshots de diagnostico.
+- Os diagnosticos podem ter valor historico limitado, mas nao parecem ser entregavel de projeto.
+- Se algum registro de progresso desses diagnosticos for importante, o ideal nao e guardar todos os artefatos brutos, e sim preservar apenas um resumo sintetico.
+- `coletores/` e um caso classico de "prototipo valido, mas fora da governanca": deve ser preservado, porem reenquadrado antes de qualquer evolucao formal.
+
+## Decisoes Tomadas
+
+- Considerar `coletores/` como material a preservar.
+- Considerar os diagnosticos brutos como descartaveis por padrao.
+- Considerar `upload_crafttext/` como descartavel, salvo descoberta posterior de valor especifico.
+- Separar a decisao sobre os scripts `.sh` da decisao sobre os produtos gerados por eles.
+- Tratar a alteracao de `data/showtrials.db` como consequencia de prototipacao, nao como progresso formal pronto para commit.
+
+## Acoes Executadas
+
+- consolidacao da origem funcional dos materiais locais
+- classificacao dos itens por valor potencial
+- formulacao de recomendacao de destino por grupo
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_04.md`
+
+## Git e GitHub
+
+- nenhum commit realizado
+- nenhuma branch criada
+- prototipo `coletores/` ainda sem issue associada
+
+## Riscos e Pendencias
+
+- `coletores/` ainda esta fora da governanca e sem rastreabilidade formal
+- `data/showtrials.db` continua alterado por efeito da prototipacao
+- os scripts `.sh` ainda precisam de decisao propria: manter, mover ou descartar
+
+## Proximo Passo Recomendado
+
+1. Decidir se os scripts `coletar_info_faltante.sh` e `coletar_info_projeto.sh` merecem preservacao
+2. Preservar `coletores/` como candidato a futura formalizacao
+3. Descartar ou arquivar fora do repositorio os diagnosticos brutos
+4. So depois decidir como tratar `data/showtrials.db` e em que momento revisar o PR `#18`
+
+## Observacoes de Governanca
+
+- `coletores/` representa trabalho fora do fluxo oficial e precisara ser reenquadrado
+- os materiais de diagnostico nao justificam, por si so, entrada no fluxo formal do projeto
+- a rodada ajuda a reduzir dispersao sem perder informacao potencialmente util

--- a/docs/planejamento/rodadas/RODADA_20260322_05.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_05.md
@@ -1,0 +1,125 @@
+# Rodada 05 - Plano Operacional de Limpeza Segura
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Depois da classificacao dos materiais locais soltos, o proximo passo natural foi transformar essa classificacao em um plano operacional concreto, sem executar nenhuma acao ainda. O foco desta rodada foi definir uma sequencia segura para limpar o working tree sem perder material relevante e sem contaminar futuros commits.
+
+## Objetivo da Rodada
+
+Produzir um plano operacional de limpeza segura do working tree atual, preservando:
+
+- `coletores/`
+- `data/showtrials.db` como estado local temporario
+- os documentos de colaboracao criados nesta fase
+
+e removendo do caminho os artefatos descartaveis.
+
+## Tipo de Rodada
+
+- `planejamento`
+
+## Inputs Analisados
+
+- `RODADA_20260322_03.md`
+- `RODADA_20260322_04.md`
+- estado atual do working tree previamente consolidado
+- preferencias do usuario sobre descarte e uso de scripts Bash
+
+## Estado Encontrado
+
+O working tree atual possui quatro grupos funcionais:
+
+1. **Documentacao nova desta colaboracao**
+   - deve ser preservada
+   - ainda nao deve ser commitada
+
+2. **Prototipacao real**
+   - `coletores/`
+   - deve ser preservado
+
+3. **Banco alterado por prototipacao**
+   - `data/showtrials.db`
+   - deve permanecer local por enquanto
+
+4. **Artefatos descartaveis**
+   - diagnosticos
+   - tarballs
+   - arquivos `git` e `gitgraph`
+   - scripts Bash antigos de coleta de diagnostico
+
+## Inferencias e Leitura do Codex
+
+- A limpeza deve ser feita por grupos, e nao com uma remocao indistinta.
+- O maior risco operacional continua sendo misturar `data/showtrials.db` com qualquer commit futuro.
+- A limpeza ideal nao precisa ser feita manualmente item por item; ela pode ser orientada por um checklist ou posteriormente automatizada por script Bash formal do projeto.
+- Como o usuario aprecia Bash para tarefas repetiveis, faz sentido pensar em um script futuro de limpeza assistida, mas nao nesta rodada.
+
+## Decisoes Tomadas
+
+- Nao executar nenhuma limpeza nesta rodada.
+- Formalizar uma sequencia recomendada antes de qualquer acao.
+- Preservar integralmente os documentos desta colaboracao e `coletores/`.
+- Nao incluir `data/showtrials.db` em nenhuma futura branch documental.
+
+## Acoes Executadas
+
+- consolidacao do plano operacional
+- definicao da ordem recomendada de limpeza
+- registro da rodada
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_05.md`
+
+## Git e GitHub
+
+- nenhum commit realizado
+- nenhuma branch criada
+- nenhuma alteracao em GitHub feita
+
+## Riscos e Pendencias
+
+- a limpeza ainda nao foi executada
+- `data/showtrials.db` continua como alteracao rastreada
+- `coletores/` segue sem enquadramento formal em issue
+- o PR `#18` continua pendente de revisao apos esta etapa
+
+## Proximo Passo Recomendado
+
+Executar a limpeza segura do working tree em quatro passos conceituais:
+
+1. **Congelar mentalmente o que deve ficar**
+   - docs desta colaboracao
+   - `coletores/`
+   - `data/showtrials.db`
+
+2. **Remover os descartaveis**
+   - `upload_crafttext/`
+   - `diagnostico_20260302_233956/`
+   - `diagnostico_20260302_233956.tar.gz`
+   - `diagnostico_fix_20260302_234244/`
+   - `diagnostico_fix_20260302_234244.tar.gz`
+   - `git`
+   - `gitgraph`
+   - `coletar_info_faltante.sh`
+   - `coletar_info_projeto.sh`
+
+3. **Revalidar o working tree**
+   - confirmar que restaram apenas:
+     - docs novos
+     - `coletores/`
+     - `data/showtrials.db`
+
+4. **So depois seguir para a revisao do PR `#18`**
+
+## Observacoes de Governanca
+
+- o plano respeita a regra de nao sair fazendo commits a partir de uma `main` desorganizada
+- a rodada e preparatoria e legitima dentro da fase de alinhamento operacional
+- a resolucao do PR `#18` continua sendo o proximo item formal da milestone apos a limpeza local

--- a/docs/planejamento/rodadas/RODADA_20260322_06.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_06.md
@@ -1,0 +1,124 @@
+# Rodada 06 - Revisao Estruturada do PR 18
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Depois da limpeza do working tree e da classificacao dos materiais locais, a prioridade formal passou a ser a revisao do PR `#18`, ligado a issue `#6` da milestone ativa `MVP - Engine de Pipeline`.
+
+## Objetivo da Rodada
+
+Revisar o PR `#18` contra:
+
+- a issue `#6`
+- a governanca
+- o quality flow
+- o risco de mudancas fora de escopo
+
+## Tipo de Rodada
+
+- `revisao`
+- `diagnostico`
+
+## Inputs Analisados
+
+- `gh pr view 18 --comments`
+- `git diff --stat main..infra/quality-pipeline-6`
+- `git diff --name-only main..infra/quality-pipeline-6`
+- `git log --oneline main..infra/quality-pipeline-6`
+- diffs principais em:
+  - `.github/workflows/ci.yml`
+  - `pyproject.toml`
+  - `.pre-commit-config.yaml`
+  - `docs/quality.md`
+  - `docs/flow.md`
+  - `src/infrastructure/registry.py`
+  - `src/infrastructure/translation/google_translator.py`
+  - `src/interface/web/app.py`
+  - `src/application/use_cases/classificar_documento.py`
+  - testes selecionados
+
+## Estado Encontrado
+
+### Escopo real do PR
+
+O PR altera 37 arquivos, com `721` insercoes e `219` remocoes.
+
+Ele inclui:
+
+- consolidacao do CI via Taskipy
+- ajustes em `pyproject.toml`
+- atualizacao de hooks de pre-commit
+- nova documentacao de qualidade
+- adicao de stubs e configuracao de mypy
+- varias alteracoes em codigo de aplicacao, infraestrutura, web e testes
+
+### Nucleo aderente a issue #6
+
+Os elementos abaixo estao aderentes ao objetivo da issue:
+
+- CI chamando `poetry run task pre-push`
+- geracao de `coverage.xml`
+- adiciona `types-pyyaml`
+- consolidacao de configuracao de Ruff no `pyproject.toml`
+- documentacao operacional em `docs/quality.md`
+
+### Pontos de tensao
+
+1. O PR esta mais amplo do que o escopo da issue sugere.
+2. A documentacao nova possui inconsistencias internas.
+3. Ha material documental auxiliar (`docs/flow.md`) que parece mais playbook de execucao da issue do que documentacao de projeto.
+
+## Inferencias e Leitura do Codex
+
+- O PR nao parece perigoso por bug funcional evidente, mas esta amplo demais para um merge confortavel dentro da governanca atual.
+- O problema principal nao e "codigo errado", mas "escopo insuficientemente contido".
+- O merge seria mais seguro se o PR fosse ajustado para reduzir ruido e corrigir contradicoes documentais.
+
+## Decisoes Tomadas
+
+- Nao recomendar merge imediato sem ajustes.
+- Tratar o PR como **quase pronto**, mas ainda precisando refinamento.
+- Priorizar correcao de escopo e consistencia documental antes de discutir fechamento da issue `#6`.
+
+## Acoes Executadas
+
+- revisao comparativa entre `main` e `infra/quality-pipeline-6`
+- leitura de diff de arquivos centrais
+- avaliacao de aderencia contra issue e flows
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_06.md`
+
+## Git e GitHub
+
+- branch revisada: `infra/quality-pipeline-6`
+- PR revisado: `#18`
+- issue relacionada: `#6`
+- milestone relacionada: `MVP - Engine de Pipeline`
+
+## Riscos e Pendencias
+
+- PR com escopo mais largo do que a issue aparenta
+- contradicao em `docs/quality.md` sobre MyPy ser ou nao gate
+- inclusao de `docs/flow.md`, que parece muito especifico da execucao da issue
+- necessidade de decidir se ajustes serao feitos no mesmo PR ou por reducao de escopo
+
+## Proximo Passo Recomendado
+
+1. Ajustar o PR `#18` antes do merge
+2. Corrigir inconsistencias em `docs/quality.md`
+3. Decidir se `docs/flow.md` deve sair do PR
+4. Reavaliar se todas as alteracoes em codigo sao realmente necessarias para a issue `#6`
+5. So depois decidir merge e fechamento da issue
+
+## Observacoes de Governanca
+
+- o PR esta bem alinhado em intencao, mas nao plenamente em contencao de escopo
+- a governanca favorece mudancas pequenas, verificaveis e sem desvio de responsabilidade
+- portanto, o ajuste recomendado e coerente com o metodo do projeto

--- a/docs/planejamento/rodadas/RODADA_20260322_07.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_07.md
@@ -1,0 +1,96 @@
+# Rodada 07 - Correcao de Rota sobre o Uso de Stash
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Ao iniciar a execucao do plano de saneamento do PR `#18`, o usuario observou corretamente dois pontos:
+
+1. o passo a passo anterior nao explicitou com clareza em qual branch agir
+2. a trilha documental da execucao precisava continuar sendo atualizada
+
+O usuario executou `git stash push -u -m "wip/alinhamento-operacional-codex"` estando na branch `main`.
+
+## Objetivo da Rodada
+
+Corrigir o enquadramento conceitual do uso do `stash`, registrar o ocorrido e ajustar a orientacao operacional daqui para frente.
+
+## Tipo de Rodada
+
+- `diagnostico`
+- `planejamento`
+
+## Inputs Analisados
+
+- `git stash list`
+- `git status --short`
+- feedback direto do usuario sobre a execucao do passo anterior
+
+## Estado Encontrado
+
+### Estado do stash
+
+Foi criado com sucesso:
+
+- `stash@{0}: On main: wip/alinhamento-operacional-codex`
+
+### Estado da arvore
+
+Depois do `stash`, a arvore ficou limpa para prosseguir com a analise e cirurgia das branches do PR.
+
+## Inferencias e Leitura do Codex
+
+- O usuario esta certo em cobrar explicitude sobre branch e documentacao.
+- O fato de o `stash` ter sido criado na `main` nao comprometeu o processo.
+- `git stash` nao "pertence" de forma rigida a uma branch; ele captura o estado do working tree e do index naquele momento.
+- O nome `On main` apenas registra de onde ele foi criado, o que inclusive ajuda na rastreabilidade.
+
+## Decisoes Tomadas
+
+- Registrar explicitamente o uso do stash nesta rodada.
+- Passar a explicitar melhor o contexto de branch em comandos sensiveis.
+- Manter o stash atual como ponto seguro para recuperar:
+  - docs desta colaboracao
+  - `coletores/`
+  - alteracao em `data/showtrials.db`
+
+## Acoes Executadas
+
+- verificacao do stash criado
+- verificacao do estado atual do working tree
+- registro documental da correcao de rota
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_07.md`
+
+## Git e GitHub
+
+- stash confirmado: `stash@{0}`
+- branch observada no momento da criacao do stash: `main`
+- working tree limpa apos stash
+
+## Riscos e Pendencias
+
+- o risco principal agora nao e o stash, mas retomar a execucao com passos bem enquadrados por branch
+- ainda faltam os comentarios na issue `#6` e no PR `#18`
+- ainda falta iniciar formalmente a cirurgia do PR em branches novas
+
+## Proximo Passo Recomendado
+
+Prosseguir com os passos seguintes, agora com enquadramento explicito:
+
+1. ainda na `main` limpa, comentar issue `#6`
+2. ainda na `main` limpa, comentar PR `#18`
+3. criar branch `infra/quality-pipeline-core` a partir da `main`
+4. fazer a cirurgia por `cherry-pick`
+
+## Observacoes de Governanca
+
+- o `stash` na `main` nao violou a governanca, porque nao gerou commit nem alteracao historica
+- a observacao do usuario melhorou a qualidade do protocolo operacional
+- a rodada reforca a importancia de registrar nao apenas as decisoes, mas tambem os desvios e correcoes de rota

--- a/docs/planejamento/rodadas/RODADA_20260322_08.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_08.md
@@ -1,0 +1,103 @@
+# Rodada 08 - Parecer Operacional sobre Issue 6 e PR 18
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Apos a inspecao do PR `#18` e da issue `#6`, foi necessario consolidar um parecer operacional antes de qualquer acao em branch. Esta rodada documenta as decisoes tomadas nesse momento, antes da criacao do stash usado para proteger o working tree.
+
+## Objetivo da Rodada
+
+Registrar formalmente o parecer sobre:
+
+- estado do PR `#18`
+- relacao com a issue `#6`
+- necessidade de ajuste antes de merge
+- papel de `docs/quality.md` e `docs/flow.md`
+
+## Tipo de Rodada
+
+- `revisao`
+- `planejamento`
+
+## Inputs Analisados
+
+- issue `#6`
+- PR `#18`
+- diff entre `main` e `infra/quality-pipeline-6`
+- arquivos de configuracao, CI, docs e trechos de `src/`
+
+## Estado Encontrado
+
+O PR `#18` estava conceitualmente alinhado a issue `#6`, mas com escopo mais amplo do que o desejado.
+
+Foram identificados dois eixos misturados:
+
+1. consolidacao do pipeline de qualidade
+   - CI
+   - Taskipy
+   - `pyproject.toml`
+   - pre-commit
+   - coverage
+   - docs de qualidade
+
+2. ajustes espalhados de baseline/tipagem
+   - codigo em `src/`
+   - testes
+
+Tambem foi observado que:
+
+- `docs/quality.md` precisava ser atualizado para refletir o estado mais recente da branch
+- `docs/flow.md` nao parecia documento de destaque da raiz de `docs/`, e sim playbook operacional especifico
+
+## Inferencias e Leitura do Codex
+
+- O PR nao estava "errado", mas estava dificil de revisar e explicar como unidade unica.
+- A issue `#6` deveria permanecer em `In review` ate haver uma apresentacao mais contida da solucao.
+- O melhor caminho seria ajustar ou dividir o PR, em vez de mergear imediatamente.
+
+## Decisoes Tomadas
+
+- Nao recomendar merge imediato do PR `#18`
+- Recomendar saneamento antes do merge
+- Tratar `docs/quality.md` como documento que deveria ser corrigido
+- Reenquadrar `docs/flow.md` para local menos destacado
+- Manter a issue `#6` em `In review`
+
+## Acoes Executadas
+
+- consolidacao do parecer tecnico-operacional
+- definicao de recomendacao de ajuste antes de merge
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_08.md`
+
+## Git e GitHub
+
+- PR avaliado: `#18`
+- issue relacionada: `#6`
+- milestone envolvida: `MVP - Engine de Pipeline`
+
+## Riscos e Pendencias
+
+- PR ainda misturando mais de uma linha de trabalho
+- documentacao de qualidade potencialmente desatualizada em relacao ao estado real da branch
+- necessidade de definir o destino de `docs/flow.md`
+
+## Proximo Passo Recomendado
+
+Documentar o plano de saneamento do PR, incluindo:
+
+- comentarios em issue e PR
+- hipotese de divisao em dois PRs
+- uso de `cherry-pick`
+
+## Observacoes de Governanca
+
+- a decisao de nao mergear imediatamente foi coerente com a governanca
+- a preocupacao principal foi contencao de escopo, nao rejeicao da direcao tecnica

--- a/docs/planejamento/rodadas/RODADA_20260322_09.md
+++ b/docs/planejamento/rodadas/RODADA_20260322_09.md
@@ -1,0 +1,106 @@
+# Rodada 09 - Plano de Saneamento do PR 18 com Divisao em Dois PRs
+
+## Data
+
+`22/03/2026`
+
+## Contexto
+
+Depois do parecer operacional sobre o PR `#18`, foi definido um plano mais concreto para sanea-lo. Esta rodada documenta a hipotese de divisao do trabalho em dois PRs menores, com base na leitura dos commits da branch `infra/quality-pipeline-6`.
+
+## Objetivo da Rodada
+
+Registrar a estrategia de saneamento do PR `#18`, incluindo:
+
+- comentarios na issue `#6` e no PR `#18`
+- inspecao por blocos
+- hipotese de divisao em dois PRs
+- uso de `cherry-pick`
+
+## Tipo de Rodada
+
+- `planejamento`
+
+## Inputs Analisados
+
+- `git diff --stat main..infra/quality-pipeline-6`
+- `git diff --name-only main..infra/quality-pipeline-6`
+- `git log --oneline main..infra/quality-pipeline-6`
+- leituras por blocos em:
+  - infra/config/docs
+  - `src/`
+  - testes
+
+## Estado Encontrado
+
+Os commits da branch `infra/quality-pipeline-6` se organizavam naturalmente em dois grupos:
+
+### Grupo A - Core do pipeline de qualidade
+
+- `a120d3a`
+- `55edf67`
+- `96d9424`
+- `e791dc0`
+- `23bc67a`
+- `f0104ea`
+- `df915e2`
+- `d0ec2bd`
+- `4097837`
+
+### Grupo B - Baseline fixes no codigo
+
+- `ff68aa9`
+- `4cfa7c2`
+
+## Inferencias e Leitura do Codex
+
+- A divisao em dois PRs parecia mais limpa do que tentar defender o PR atual como unidade unica.
+- O Grupo A se aproxima da issue `#6` como consolidacao de pipeline de qualidade.
+- O Grupo B se aproxima de estabilizacao de baseline de tipagem e testes.
+
+## Decisoes Tomadas
+
+- Recomendar comentarios na issue `#6` e no PR `#18` antes da cirurgia
+- Recomendar criacao de:
+  - `infra/quality-pipeline-core`
+  - `infra/mypy-baseline-fixes`
+- Recomendar fechar o PR `#18` apenas depois da abertura dos novos PRs
+
+## Acoes Executadas
+
+- definicao do plano de divisao
+- mapeamento preliminar dos commits por grupo
+- definicao da ordem operacional sugerida
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260322_09.md`
+
+## Git e GitHub
+
+- branch fonte do plano: `infra/quality-pipeline-6`
+- PR fonte do plano: `#18`
+- issue relacionada: `#6`
+
+## Riscos e Pendencias
+
+- a divisao ainda dependia de execucao pratica
+- `docs/quality.md` ainda precisaria de revisao manual
+- `docs/flow.md` ainda precisava de decisao final: mover, remover ou reenquadrar
+
+## Proximo Passo Recomendado
+
+1. Proteger o working tree com stash
+2. Comentar issue e PR
+3. Criar `infra/quality-pipeline-core`
+4. Executar `cherry-pick` do Grupo A
+5. Corrigir docs
+6. Criar `infra/mypy-baseline-fixes`
+7. Executar `cherry-pick` do Grupo B
+
+## Observacoes de Governanca
+
+- a proposta de divisao atende melhor ao principio de mudancas pequenas e verificaveis
+- a estrategia reduz risco de escopo excessivo no PR ligado a issue `#6`

--- a/docs/planejamento/rodadas/RODADA_20260323_01.md
+++ b/docs/planejamento/rodadas/RODADA_20260323_01.md
@@ -1,0 +1,206 @@
+# Rodada 01 - Auditoria das Rodadas Recuperadas e Resgate de Artefatos
+
+## Data
+
+`23/03/2026`
+
+## Contexto
+
+Apos uma fase operacional longa envolvendo stash, cirurgia de branches e reconfiguracao do PR da issue `#6`, surgiu a percepcao de perda de materiais importantes da colaboracao com o Codex, especialmente:
+
+- `coletores/`
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_06.md`
+
+O usuario cobrou explicitamente:
+
+- rastreabilidade do que foi modificado
+- localizacao dos documentos e scripts supostamente perdidos
+- uma auditoria objetiva do que as rodadas registram
+- documentacao formal desta rodada de analise
+
+## Objetivo da Rodada
+
+1. Auditar o conteudo das rodadas `01` a `09`
+2. Confirmar onde estavam os artefatos desaparecidos
+3. Resgatar evidencias sobre `coletores/` e documentos da colaboracao
+4. Registrar o desvio operacional ocorrido e a recuperacao parcial executada
+
+## Tipo de Rodada
+
+- `diagnostico`
+- `revisao`
+- `planejamento`
+
+## Inputs Analisados
+
+- `git stash list`
+- `git reflog stash --date=iso`
+- `git stash show -p stash@{0} --stat`
+- `git fsck --full --no-reflogs --unreachable --lost-found`
+- `git rev-parse <stash/commit>`
+- `git ls-tree -r --name-only <objeto>`
+- `git show <objeto>:coletores/livro_lenin/extractor_livro.py`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md`
+- `docs/planejamento/rodadas/RODADA_20260322_02.md`
+- `docs/planejamento/rodadas/RODADA_20260322_03.md`
+- `docs/planejamento/rodadas/RODADA_20260322_04.md`
+- `docs/planejamento/rodadas/RODADA_20260322_05.md`
+- `docs/planejamento/rodadas/RODADA_20260322_06.md`
+- `docs/planejamento/rodadas/RODADA_20260322_07.md`
+- `docs/planejamento/rodadas/RODADA_20260322_08.md`
+- `docs/planejamento/rodadas/RODADA_20260322_09.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/projeto/manual_colaboracao_codex.md`
+
+## Estado Encontrado
+
+### Rodadas auditadas
+
+As rodadas recuperadas registram uma narrativa coerente da fase inicial:
+
+- `01`: alinhamento inicial de contexto do projeto
+- `02`: diagnostico do estado operacional da `main`
+- `03`: triagem do working tree e precedencia do PR `#18`
+- `04`: classificacao de materiais locais soltos
+- `05`: plano operacional de limpeza segura
+- `06`: revisao estruturada do PR `#18`
+- `07`: correcao de rota sobre uso de stash
+- `08`: parecer operacional sobre issue `#6` e PR `#18`
+- `09`: plano de saneamento do PR `#18` com hipotese de divisao em dois PRs
+
+### Conteudo dos documentos auxiliares
+
+Foi confirmada a existencia e recuperacao de:
+
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+
+O manual estabelece:
+
+- papeis do Codex no projeto
+- niveis de autonomia
+- contrato de uso
+- obrigacao de documentos de rodada
+
+### Estado do stash atual
+
+No `stash@{0}` foram encontrados apenas:
+
+- `RODADA_20260322_07.md`
+- `RODADA_20260322_08.md`
+- `RODADA_20260322_09.md`
+
+### Descoberta critica
+
+Os arquivos considerados perdidos nao estavam no `stash@{0}` atual, mas foram localizados no terceiro pai do stash antigo descartado `2348da8ec13fc8190176a42a403f9e8fd86b1bb3`, no objeto:
+
+- `e53ec2ac316ad6af93b0878835c283bf00d5905b`
+
+Dentro desse objeto foram localizados:
+
+- `coletores/info.md`
+- `coletores/livro_lenin/coleta_livro.py`
+- `coletores/livro_lenin/debug_extractor.py`
+- `coletores/livro_lenin/extractor_livro.py`
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `06.md`
+
+### Recuperacao executada pelo usuario
+
+O usuario executou com sucesso:
+
+```bash
+git checkout e53ec2ac316ad6af93b0878835c283bf00d5905b -- \
+  coletores \
+  docs/projeto/manual_colaboracao_codex.md \
+  docs/planejamento/rodadas
+```
+
+Com isso, foram recuperados para a working tree da `main`:
+
+- `coletores/`
+- `manual_colaboracao_codex.md`
+- `TEMPLATE_RODADA.md`
+- `RODADA_20260322_01.md` ate `RODADA_20260322_06.md`
+
+As rodadas `07`, `08` e `09` ja estavam presentes como arquivos untracked, oriundos do stash atual aplicado anteriormente.
+
+## Inferencias e Leitura do Codex
+
+- Os documentos de rodada formam uma narrativa consistente da fase de alinhamento e da tentativa de saneamento do PR `#18`.
+- O sumico aparente dos arquivos nao foi destruicao definitiva, mas deslocamento entre diferentes estruturas de stash.
+- Houve perda de confianca operacional porque o gerenciamento de contexto e de rastreabilidade da sessao falhou do lado do Codex.
+- A recuperacao confirma que os materiais centrais da colaboracao sobreviveram em objetos Git nao imediatamente visiveis.
+- O contrato de uso do manual foi parcialmente violado na fase de execucao posterior, especialmente no grau de autonomia e na falta de pausas explicitas antes de editar codigo.
+
+## Decisoes Tomadas
+
+- Auditar antes de qualquer novo commit documental.
+- Priorizar leitura e preservacao dos materiais recuperados.
+- Registrar formalmente a existencia de desvio operacional na colaboracao.
+- Nao assumir inexistencia de arquivos sem antes consultar stash, objetos perdidos e refs auxiliares do Git.
+
+## Acoes Executadas
+
+- leitura integral das rodadas `01` a `09`
+- leitura do template e do manual de colaboracao
+- inspeccao do stash atual
+- busca por objetos perdidos com `git fsck`
+- identificacao do objeto `e53ec2ac...` como fonte de recuperacao
+- validacao do conteudo de `coletores/livro_lenin/extractor_livro.py`
+- orientacao de comando de resgate, executado com sucesso pelo usuario
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260323_01.md`
+
+### Arquivos recuperados para a working tree
+
+- `coletores/info.md`
+- `coletores/livro_lenin/coleta_livro.py`
+- `coletores/livro_lenin/debug_extractor.py`
+- `coletores/livro_lenin/extractor_livro.py`
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_06.md`
+- `docs/planejamento/rodadas/RODADA_20260322_07.md`
+- `docs/planejamento/rodadas/RODADA_20260322_08.md`
+- `docs/planejamento/rodadas/RODADA_20260322_09.md`
+
+## Git e GitHub
+
+- branch atual observada: `main`
+- stash atual ainda existente: `stash@{0}: On main: wip/alinhamento-operacional-codex-v2`
+- objeto critico de recuperacao localizado: `e53ec2ac316ad6af93b0878835c283bf00d5905b`
+- PR operacional relevante desta fase: `#19`
+- PR anterior fechado durante a fase: `#18`
+
+## Riscos e Pendencias
+
+- os arquivos recuperados estao em estado local e ainda exigem decisao de versionamento
+- a trilha documental da fase operacional posterior ainda nao esta totalmente consolidada
+- a branch `infra/quality-pipeline-core` precisa de auditoria separada se o usuario desejar revisar o que foi efetivamente alterado no PR `#19`
+- o estado do stash atual continua precisando de decisao futura: manter, dropar ou aplicar seletivamente
+
+## Proximo Passo Recomendado
+
+1. Tirar todos os arquivos recuperados do stage, se a intencao for apenas preservar e analisar
+2. Ler com calma:
+   - `manual_colaboracao_codex.md`
+   - `TEMPLATE_RODADA.md`
+   - `RODADA_20260322_01.md` ate `09.md`
+3. Decidir quais documentos entram formalmente no projeto
+4. Separadamente, auditar a branch `infra/quality-pipeline-core` para decidir o destino do PR `#19`
+
+## Observacoes de Governanca
+
+- Esta rodada expoe um desvio importante de governanca operacional na colaboracao com o Codex:
+  - houve autonomia excessiva em fase de execucao
+  - houve perda temporaria de rastreabilidade percebida pelo usuario
+- O resgate bem-sucedido mitiga a perda material, mas nao elimina a necessidade de realinhar o contrato de uso.
+- A partir desta rodada, a documentacao de colaboracao deve voltar a ser tratada como artefato normativo do processo, nao apenas memoria auxiliar.

--- a/docs/planejamento/rodadas/RODADA_20260323_02.md
+++ b/docs/planejamento/rodadas/RODADA_20260323_02.md
@@ -1,0 +1,157 @@
+# Rodada 02 - Resgate de Artefatos e Auditoria do Estado Recuperado
+
+## Data
+
+`23/03/2026`
+
+## Contexto
+
+Durante a fase de alinhamento operacional e cirurgia de branches, surgiu a percepcao de perda de materiais importantes da colaboracao com o Codex, especialmente:
+
+- `coletores/`
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_06.md`
+
+Foi necessario interromper a continuidade da execucao para localizar e recuperar esses artefatos com seguranca.
+
+## Objetivo da Rodada
+
+- localizar os artefatos supostamente perdidos
+- auditar o estado das rodadas ja registradas
+- confirmar a origem do material recuperado
+- restaurar os arquivos para a working tree sem perder rastreabilidade
+
+## Tipo de Rodada
+
+- `diagnostico`
+- `revisao`
+- `execucao`
+
+## Inputs Analisados
+
+- `git stash list`
+- `git stash show --name-only stash@{0}`
+- `git show stash@{0}^3:...`
+- `git fsck --full --no-reflogs --unreachable --lost-found`
+- `git rev-parse 2348da8...^3`
+- `git ls-tree -r --name-only e53ec2ac316ad6af93b0878835c283bf00d5905b`
+- leitura de `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_09.md`
+- leitura de `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- leitura de `docs/projeto/manual_colaboracao_codex.md`
+
+## Estado Encontrado
+
+### Stash atual
+
+O `stash@{0}` continha apenas:
+
+- `RODADA_20260322_07.md`
+- `RODADA_20260322_08.md`
+- `RODADA_20260322_09.md`
+
+### Objeto de recuperacao
+
+Os arquivos considerados perdidos foram localizados no terceiro pai do stash antigo descartado `2348da8ec13fc8190176a42a403f9e8fd86b1bb3`, no objeto:
+
+- `e53ec2ac316ad6af93b0878835c283bf00d5905b`
+
+Dentro desse objeto foram encontrados:
+
+- `coletores/info.md`
+- `coletores/livro_lenin/coleta_livro.py`
+- `coletores/livro_lenin/debug_extractor.py`
+- `coletores/livro_lenin/extractor_livro.py`
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_06.md`
+
+### Rodadas auditadas
+
+As rodadas `01` a `09` formam uma narrativa coerente da fase inicial:
+
+- alinhamento do contexto e da governanca
+- triagem do working tree
+- classificacao dos materiais locais
+- plano de limpeza segura
+- revisao do PR `#18`
+- uso de stash
+- tentativa de saneamento por divisao em dois PRs
+
+## Inferencias e Leitura do Codex
+
+- O material nao havia sido destruido definitivamente, mas deslocado entre estruturas diferentes de stash/objetos Git.
+- A percepcao de perda decorreu de falha de rastreabilidade operacional durante a sessao.
+- O contrato de uso foi tensionado na fase de execucao posterior, especialmente em autonomia e explicitude.
+- O projeto precisava voltar imediatamente para uma trilha de preservacao e documentacao, antes de qualquer nova frente.
+
+## Decisoes Tomadas
+
+- priorizar o resgate antes de qualquer outra acao
+- restaurar o material para a working tree da `main`
+- reconstituir a base documental da colaboracao
+- registrar formalmente o desvio e o resgate
+
+## Acoes Executadas
+
+- localizacao do objeto `e53ec2ac316ad6af93b0878835c283bf00d5905b`
+- validacao do conteudo de `coletores/livro_lenin/extractor_livro.py`
+- recuperacao orientada pelo comando:
+
+```bash
+git checkout e53ec2ac316ad6af93b0878835c283bf00d5905b -- \
+  coletores \
+  docs/projeto/manual_colaboracao_codex.md \
+  docs/planejamento/rodadas
+```
+
+- confirmacao da volta de:
+  - `coletores/`
+  - `manual_colaboracao_codex.md`
+  - `TEMPLATE_RODADA.md`
+  - rodadas `01` a `09`
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260323_02.md`
+
+### Arquivos recuperados
+
+- `coletores/info.md`
+- `coletores/livro_lenin/coleta_livro.py`
+- `coletores/livro_lenin/debug_extractor.py`
+- `coletores/livro_lenin/extractor_livro.py`
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_09.md`
+
+## Git e GitHub
+
+- branch observada durante o resgate: `main`
+- stash ainda existente no momento da analise: `stash@{0}: On main: wip/alinhamento-operacional-codex-v2`
+- objeto de recuperacao confirmado: `e53ec2ac316ad6af93b0878835c283bf00d5905b`
+- PRs abertos relevantes nesta fase:
+  - PR da issue `#6`
+  - PR documental
+  - PR de `coletores/`
+
+## Riscos e Pendencias
+
+- os artefatos recuperados precisavam ser reenquadrados no fluxo oficial
+- a documentacao ainda nao estava commitada em branch propria
+- `coletores/` ainda estava sem issue e PR proprios no momento do resgate
+
+## Proximo Passo Recomendado
+
+1. separar documentacao de colaboracao e prototipo `coletores/`
+2. abrir branch documental para levar manual, template e rodadas para `main`
+3. formalizar `coletores/` em issue/branch/PR proprios
+4. so depois retomar a avaliacao das frentes tecnicas pendentes
+
+## Observacoes de Governanca
+
+- a rodada reestabelece rastreabilidade depois de uma quebra de confianca operacional
+- houve desvio relevante do contrato de uso na fase anterior, mas o resgate recuperou os artefatos centrais
+- a partir daqui, a prioridade volta a ser separar frentes e preservar commits atomicos

--- a/docs/planejamento/rodadas/RODADA_20260323_03.md
+++ b/docs/planejamento/rodadas/RODADA_20260323_03.md
@@ -1,0 +1,134 @@
+# Rodada 03 - Estabilizacao com Branch Documental e Formalizacao de Coletores
+
+## Data
+
+`23/03/2026`
+
+## Contexto
+
+Depois do resgate dos artefatos, foi necessario transformar esse estado local recuperado em algo operacionalmente estavel. O usuario definiu duas diretrizes importantes:
+
+- manual, template e rodadas sao documentacao oficial e devem chegar a `main`
+- `coletores/` deve seguir fluxo proprio com issue e PR dedicados
+
+## Objetivo da Rodada
+
+- estabilizar a documentacao recuperada em branch propria
+- manter `coletores/` fora do commit documental
+- formalizar `coletores/` com issue e PR especificos
+- deixar o projeto em estado mais limpo para decidir proximos passos
+
+## Tipo de Rodada
+
+- `planejamento`
+- `execucao`
+
+## Inputs Analisados
+
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_09.md`
+- `docs/planejamento/rodadas/RODADA_20260323_01.md`
+- estado do working tree apos resgate
+- issue `#21`
+- PR de documentacao criado pelo usuario
+- PR `#22` criado para `coletores/`
+
+## Estado Encontrado
+
+### Documentacao
+
+A documentacao recuperada foi separada em branch propria:
+
+- `docs/manual-e-rodadas-codex`
+
+Foi realizado o commit:
+
+- `9d52273` `docs: adiciona manual e rodadas da colaboracao com Codex`
+
+Esse commit incluiu:
+
+- `manual_colaboracao_codex.md`
+- `TEMPLATE_RODADA.md`
+- `RODADA_20260322_01.md` ate `RODADA_20260322_09.md`
+- `RODADA_20260323_01.md`
+
+### Coletores
+
+O diretorio `coletores/` foi mantido fora do commit documental e formalizado em frente separada:
+
+- issue `#21`
+- branch `spike/coletores-fontes-externas-21`
+- PR `#22`
+
+## Inferencias e Leitura do Codex
+
+- O usuario estava correto em exigir que manual, template e rodadas fossem tratados como documentacao oficial do projeto, e nao como material adiado indefinidamente.
+- A separacao entre documentacao oficial e prototipo tecnico restabelece melhor aderencia a governanca.
+- O repositorio entrou em um estado significativamente mais estavel do que na fase inicial desta sessao.
+
+## Decisoes Tomadas
+
+- manter a estrutura documental ja definida, sem inventar novos caminhos
+- levar a documentacao de colaboracao para `main` via PR proprio
+- tratar `coletores/` como prototipo formalizado em trilha separada
+- adiar apenas a definicao mais ampla sobre estrategia futura de push/merge/commit
+
+## Acoes Executadas
+
+- criacao da branch `docs/manual-e-rodadas-codex`
+- commit da documentacao oficial da colaboracao
+- push da branch documental
+- criacao do PR documental pelo usuario
+- criacao da issue `#21` para `coletores/`
+- criacao da branch `spike/coletores-fontes-externas-21`
+- commit e push de `coletores/`
+- criacao do PR `#22`
+
+## Arquivos Afetados
+
+### Criado nesta rodada
+
+- `docs/planejamento/rodadas/RODADA_20260323_03.md`
+
+### Formalizados nesta rodada
+
+- `docs/projeto/manual_colaboracao_codex.md`
+- `docs/planejamento/rodadas/TEMPLATE_RODADA.md`
+- `docs/planejamento/rodadas/RODADA_20260322_01.md` ate `RODADA_20260322_09.md`
+- `docs/planejamento/rodadas/RODADA_20260323_01.md`
+- `coletores/info.md`
+- `coletores/livro_lenin/coleta_livro.py`
+- `coletores/livro_lenin/debug_extractor.py`
+- `coletores/livro_lenin/extractor_livro.py`
+
+## Git e GitHub
+
+- branch documental: `docs/manual-e-rodadas-codex`
+- branch de prototipo: `spike/coletores-fontes-externas-21`
+- issue criada para `coletores/`: `#21`
+- PR criado para `coletores/`: `#22`
+- PR documental: criado pelo usuario nesta rodada
+- PR tecnico pendente de fase anterior: `#19`
+
+## Riscos e Pendencias
+
+- ainda falta decidir o destino do PR `#19`
+- ainda falta consolidar a estrategia futura de pushes, merges e commits
+- a documentacao desta propria fase precisava ser adicionada ao PR documental
+
+## Proximo Passo Recomendado
+
+1. commitar as rodadas desta fase na branch documental
+2. atualizar o PR documental
+3. depois revisar o quadro completo de PRs abertos:
+   - PR documental
+   - PR `#22`
+   - PR `#19`
+4. a partir desse quadro, definir a ordem dos proximos merges e a retomada do foco da engine
+
+## Observacoes de Governanca
+
+- esta rodada corrigiu uma das principais tensoes da sessao: a documentacao oficial passou a ter fluxo proprio e alinhado ao projeto
+- `coletores/` deixou de ser apenas material local e ganhou rastreabilidade formal
+- a partir daqui, o trabalho pode prosseguir de forma mais consistente com `manual_colaboracao_codex.md`, `git_flow.md` e `quality_flow.md`

--- a/docs/planejamento/rodadas/TEMPLATE_RODADA.md
+++ b/docs/planejamento/rodadas/TEMPLATE_RODADA.md
@@ -1,0 +1,78 @@
+# Rodada XX - Titulo Curto
+
+## Data
+
+`DD/MM/AAAA`
+
+## Contexto
+
+Descreva o que motivou esta rodada e em que ponto do projeto ela aconteceu.
+
+## Objetivo da Rodada
+
+Defina com clareza o objetivo principal desta interacao.
+
+## Tipo de Rodada
+
+- `leitura`
+- `diagnostico`
+- `planejamento`
+- `execucao`
+- `revisao`
+
+## Inputs Analisados
+
+Liste os principais insumos usados na rodada:
+
+- arquivos lidos
+- comandos executados
+- estado de Git/GitHub
+- documentos de referencia
+
+## Estado Encontrado
+
+Descreva os fatos confirmados durante a rodada.
+
+## Inferencias e Leitura do Codex
+
+Registre as conclusoes interpretativas que nao sao fatos diretos, mas inferencias a partir dos insumos.
+
+## Decisoes Tomadas
+
+Liste as decisoes ou consensos obtidos na rodada.
+
+## Acoes Executadas
+
+Descreva o que foi feito de forma objetiva.
+
+## Arquivos Afetados
+
+Liste os arquivos criados, alterados ou inspecionados de forma relevante.
+
+## Git e GitHub
+
+Registre o que importa para rastreabilidade operacional:
+
+- branch atual
+- issues relacionadas
+- PR relacionado
+- milestone
+- status do project, se aplicavel
+
+## Riscos e Pendencias
+
+Liste riscos abertos, duvidas ou pendencias.
+
+## Proximo Passo Recomendado
+
+Descreva o melhor proximo passo a partir da rodada.
+
+## Observacoes de Governanca
+
+Registre aderencia ou desvios em relacao a:
+
+- milestone ativa
+- foco estrategico
+- escopo
+- branch
+- status no board

--- a/docs/projeto/manual_colaboracao_codex.md
+++ b/docs/projeto/manual_colaboracao_codex.md
@@ -1,0 +1,545 @@
+# Manual de Colaboracao - Thiago + Codex
+
+<div align="center">
+
+**Guia operacional para uso do Codex como assistente tecnico, estrategico e de execucao no projeto ShowTrials**
+
+</div>
+
+---
+
+## Informacoes do Documento
+
+| Item | Descricao |
+|------|-----------|
+| **Status** | Ativo |
+| **Data** | 22/03/2026 |
+| **Escopo** | Colaboracao homem + IA no projeto |
+| **Relacionado a** | `GOVERNANCA.md`, `git_flow.md`, `quality_flow.md`, roadmap da engine |
+| **Objetivo central** | Definir como o Codex deve apoiar o projeto com seguranca, rastreabilidade e aderencia arquitetural |
+
+---
+
+## Objetivo
+
+Este manual define como o Codex deve ser utilizado no projeto ShowTrials para:
+
+- preservar a governanca e o foco arquitetural
+- reduzir risco de mudancas fora de escopo
+- registrar progresso de forma estruturada
+- apoiar leitura, planejamento, execucao e revisao
+- tornar o uso da IA previsivel, auditavel e util
+
+O principio central e:
+
+> O Codex nao substitui o dono do projeto nas decisoes arquiteturais.
+> O Codex acelera entendimento, execucao disciplinada e rastreabilidade.
+
+---
+
+## Papel do Codex no Projeto
+
+O Codex pode atuar em quatro papeis principais.
+
+### 1. Leitura e Sintese
+
+Usado para:
+
+- ler codigo e documentacao
+- consolidar contexto
+- comparar plano vs implementacao real
+- identificar inconsistencias
+
+Exemplos de pedido:
+
+- "Leia estes arquivos e me devolva um mapa mental."
+- "Compare a documentacao com o codigo atual."
+- "Explique esta area do projeto antes de mexermos nela."
+
+### 2. Diagnostico Tecnico
+
+Usado para:
+
+- localizar dividas e tensoes arquiteturais
+- revisar aderencia a governanca
+- avaliar PRs, issues e backlog
+- apontar riscos antes de implementar
+
+Exemplos de pedido:
+
+- "Audite este PR contra a governanca."
+- "O que esta desalinhado entre codigo, docs e roadmap?"
+- "Quais riscos existem nesta refatoracao?"
+
+### 3. Planejamento
+
+Usado para:
+
+- propor ordem de ataque
+- quebrar uma milestone em passos seguros
+- transformar visao em backlog tecnico
+- definir escopo de issue ou PR
+
+Exemplos de pedido:
+
+- "Proponha a melhor ordem para atacar estas issues."
+- "Quebre esta issue em tarefas executaveis."
+- "Monte um plano seguro para a primeira fase da engine."
+
+### 4. Execucao Controlada
+
+Usado para:
+
+- editar codigo
+- adicionar testes
+- ajustar documentacao
+- revisar ou preparar PRs
+
+Exemplos de pedido:
+
+- "Implemente a issue #10 com escopo estrito."
+- "Corrija este problema sem sair do escopo."
+- "Prepare a documentacao desta mudanca."
+
+---
+
+## Niveis de Autonomia
+
+Para uso seguro, a colaboracao pode operar em niveis.
+
+### Nivel 1 - Analise
+
+O Codex:
+
+- le contexto
+- resume
+- diagnostica
+- nao altera arquivos
+
+Quando usar:
+
+- inicio de assunto novo
+- duvida arquitetural
+- revisao de contexto
+
+### Nivel 2 - Planejamento Assistido
+
+O Codex:
+
+- analisa
+- propoe plano
+- sugere sequencia de execucao
+- pode preparar a estrategia, mas ainda sem implementar
+
+Quando usar:
+
+- antes de atacar issue importante
+- antes de refatoracao estrutural
+- quando houver multiplos caminhos possiveis
+
+### Nivel 3 - Execucao Controlada
+
+O Codex:
+
+- implementa mudancas
+- adiciona ou ajusta testes
+- valida localmente quando possivel
+- documenta o que fez
+
+Quando usar:
+
+- issue bem definida
+- escopo pequeno ou medio
+- risco controlado
+
+### Nivel 4 - Ciclo Completo
+
+O Codex:
+
+- analisa a issue
+- executa a implementacao
+- roda verificacoes
+- prepara resumo para PR
+- orienta o fechamento operacional
+
+Quando usar:
+
+- tarefas repetiveis
+- infraestrutura e qualidade
+- mudancas com padrao claro
+
+### Recomendacao Inicial
+
+Nas primeiras rodadas, usar principalmente os niveis 1 e 2.
+
+Depois de ganhar confianca:
+
+- usar nivel 3 em issues de escopo fechado
+- usar nivel 4 quando o fluxo estiver estavel
+
+---
+
+## Contrato de Uso do Codex
+
+Estas regras devem orientar cada rodada de trabalho.
+
+### Regras Gerais
+
+- O Codex nao deve assumir que pode mexer em tudo sem contexto.
+- O Codex deve respeitar a milestone ativa e a governanca.
+- O Codex nao deve trabalhar diretamente na `main`.
+- O Codex nao deve fazer refatoracao oportunista fora de escopo.
+- O Codex deve explicitar impactos arquiteturais quando existirem.
+- O Codex deve distinguir fatos, inferencias e recomendacoes.
+- O Codex deve registrar o que verificou e o que assumiu.
+
+### Regras para Mudancas de Codigo
+
+- Toda mudanca relevante deve estar associada a uma issue ou objetivo explicito.
+- Se houver duvida de escopo, o Codex deve parar e realinhar antes de expandir a mudanca.
+- Se uma mudanca estrutural surgir dentro de uma issue nao estrutural, o Codex deve sinalizar.
+- O Codex deve preservar aderencia a `quality_flow.md`, `git_flow.md` e `GOVERNANCA.md`.
+
+### Regras para Seguranca Operacional
+
+- Nao reverter alteracoes do usuario sem pedido explicito.
+- Nao fazer comandos destrutivos sem necessidade e sem alinhamento.
+- Nao "limpar" working tree do usuario por conta propria.
+- Nao ocultar riscos ou incertezas.
+
+---
+
+## Documento de Rodada
+
+Cada rodada relevante de trabalho do Codex deve gerar um documento de registro.
+
+Este documento nao substitui `FASE*.md`, mas funciona como rastreabilidade operacional de curto prazo.
+
+### Objetivo do Documento de Rodada
+
+- registrar contexto
+- documentar decisao e escopo
+- registrar o que foi analisado
+- descrever o que foi feito
+- indicar proximo passo
+
+### Quando gerar
+
+Gerar documento de rodada quando houver pelo menos um dos casos:
+
+- analise relevante de contexto
+- planejamento de issue ou milestone
+- execucao com mudancas em codigo
+- revisao de PR ou decisao arquitetural
+- consolidacao de estado Git/GitHub
+
+### Local recomendado
+
+```text
+docs/planejamento/rodadas/
+```
+
+### Convencao de nome
+
+```text
+RODADA_YYYYMMDD_NN.md
+```
+
+Exemplo:
+
+```text
+RODADA_20260322_01.md
+```
+
+### Estrutura Padrao
+
+```markdown
+# Rodada XX - Titulo curto
+
+## Data
+## Contexto
+## Objetivo da rodada
+## Inputs analisados
+## Estado encontrado
+## Decisoes tomadas
+## Acoes executadas
+## Arquivos afetados
+## Riscos / pendencias
+## Proximo passo recomendado
+## Observacoes de governanca
+```
+
+### Conteudo Minimo Obrigatorio
+
+Cada documento de rodada deve responder:
+
+1. O que motivou a rodada?
+2. O que o Codex leu ou verificou?
+3. O que foi concluido como fato?
+4. O que foi apenas inferido?
+5. Houve mudanca em codigo, docs, Git ou GitHub?
+6. Qual e o proximo passo mais recomendado?
+
+---
+
+## Relacao entre Rodadas e FASEs
+
+Os documentos de rodada e os documentos `FASE*.md` tem papeis diferentes.
+
+### Rodada
+
+- granularidade curta
+- foco operacional
+- pode registrar analise, planejamento ou execucao
+- ajuda a contar a historia do trabalho recente
+
+### FASE
+
+- granularidade maior
+- foco em entregavel consolidado
+- documenta uma intervencao importante
+- tende a ser produzida quando uma parte relevante do trabalho esta concluida
+
+### Regra pratica
+
+- varias rodadas podem alimentar uma unica FASE
+- nem toda rodada precisa virar FASE
+- toda FASE relevante pode se beneficiar do historico das rodadas anteriores
+
+---
+
+## Fluxo de Trabalho Recomendado com o Codex
+
+### Fluxo 1 - Leitura de Contexto
+
+Usar quando:
+
+- estamos iniciando um tema
+- voce quer validar se o Codex entendeu
+
+Passos:
+
+1. Informar area ou arquivos
+2. Pedir mapa mental ou diagnostico
+3. Validar entendimento
+4. Registrar rodada
+
+Prompt exemplo:
+
+```text
+Leia estes arquivos e me devolva um mapa do contexto, sem editar nada.
+```
+
+### Fluxo 2 - Planejamento de Issue
+
+Usar quando:
+
+- existe uma issue definida
+- antes de abrir branch ou codar
+
+Passos:
+
+1. Informar issue, docs e contexto
+2. Pedir plano em ordem de execucao
+3. Validar escopo
+4. Registrar rodada
+
+Prompt exemplo:
+
+```text
+Analise a issue #10 e proponha um plano de implementacao sem codar ainda.
+```
+
+### Fluxo 3 - Execucao de Issue
+
+Usar quando:
+
+- o escopo ja esta claro
+- a branch correta existe ou sera criada
+
+Passos:
+
+1. Informar issue e restricoes
+2. Codex implementa
+3. Codex roda verificacoes
+4. Codex registra rodada
+5. Codex prepara resumo para PR
+
+Prompt exemplo:
+
+```text
+Implemente a issue #10 com escopo estrito, sem sair do contrato definido.
+```
+
+### Fluxo 4 - Revisao de PR
+
+Usar quando:
+
+- existe PR aberto
+- voce quer validacao tecnica e arquitetural
+
+Passos:
+
+1. Informar PR ou branch
+2. Codex revisa contra issue, governanca e qualidade
+3. Codex aponta riscos
+4. Codex registra rodada
+
+Prompt exemplo:
+
+```text
+Revise o PR #18 contra a issue #6, a governanca e o quality flow.
+```
+
+---
+
+## Como Pedir Ajuda ao Codex
+
+Prompts simples e repetiveis funcionam melhor.
+
+### Para analise
+
+- "Leia estes arquivos e me situe."
+- "Explique esta parte do projeto."
+- "Compare documentacao e implementacao."
+
+### Para diagnostico
+
+- "O que esta desalinhado aqui?"
+- "Quais riscos existem antes de mexermos nisso?"
+- "Audite isso contra a governanca."
+
+### Para planejamento
+
+- "Qual deve ser a ordem de ataque?"
+- "Quebre esta issue em tarefas seguras."
+- "Qual o menor passo util daqui?"
+
+### Para execucao
+
+- "Implemente com escopo estrito."
+- "Corrija sem refatorar fora do necessario."
+- "Adicione testes e documente a mudanca."
+
+### Para operacao Git/GitHub
+
+- "Interprete este estado de branches/issues/PRs."
+- "Me diga o que precisa ajustar no board."
+- "Prepare o texto final para PR/issue."
+
+---
+
+## O que o Codex Faz Bem
+
+- leitura ampla e consolidacao de contexto
+- comparacao entre codigo, docs e backlog
+- proposta de ordem de execucao
+- implementacao disciplinada em escopo definido
+- revisao tecnica de riscos e regressao
+- apoio na documentacao e na rastreabilidade
+
+---
+
+## O que Exige Mais Cuidado
+
+- decisoes com trade-offs arquiteturais profundos
+- alteracoes com escopo ambiguo
+- uso de working tree muito suja
+- tarefas com muitas mudancas paralelas nao registradas
+- escolhas de produto que dependem da sua intencao de TCC
+
+Nesses casos, o Codex deve:
+
+- reduzir velocidade
+- explicitar opcoes
+- pedir alinhamento antes de executar
+
+---
+
+## Regras Especificas para o ShowTrials
+
+Considerando a governanca atual do projeto:
+
+- a milestone ativa tem precedencia sobre melhorias paralelas
+- issues `frozen` nao devem competir com a trilha principal
+- `type:engine` e `type:refactor` exigem cuidado estrutural especial
+- `quality`, `tipagem`, `testes` e `documentacao` sao parte do aceite
+- a engine deve evoluir sem apagar a historia e o valor do sistema atual
+
+---
+
+## Protocolo de Inicio de Cada Rodada
+
+Antes de qualquer trabalho relevante, o Codex deve tentar responder:
+
+1. Qual e o objetivo exato da rodada?
+2. Existe issue associada?
+3. A issue esta alinhada a milestone ativa?
+4. Ha PR aberto ou trabalho em revisao que deveria ser tratado antes?
+5. Esta rodada e de leitura, planejamento, execucao ou revisao?
+6. Precisa gerar documento de rodada? Se sim, qual sera o identificador?
+
+---
+
+## Protocolo de Encerramento de Cada Rodada
+
+Ao final de cada rodada, o Codex deve entregar:
+
+- resumo curto do que foi feito
+- fatos confirmados
+- riscos ou pendencias
+- proximo passo recomendado
+- referencia ao documento de rodada gerado, quando aplicavel
+
+Se houve mudanca em codigo:
+
+- arquivos afetados
+- verificacoes executadas
+- limitacoes do que nao foi possivel validar
+
+---
+
+## Estrategia Recomendada para as Proximas Semanas
+
+### Etapa 1 - Consolidar Operacao
+
+- revisar PR `#18`
+- ajustar board e status
+- alinhar milestone e labels restantes
+
+### Etapa 2 - Entrar na Engine com Passos Pequenos
+
+- contratos primeiro
+- executor minimo depois
+- configuracao YAML em seguida
+- migracao de um caso real por ultimo
+
+### Etapa 3 - Manter Rastreabilidade
+
+- gerar documentos de rodada
+- consolidar FASE quando houver entregavel maior
+- manter coerencia entre docs, issues, board e codigo
+
+---
+
+## Decisao Inicial Recomendada
+
+No momento inicial de uso do Codex neste projeto:
+
+- usar o Codex primeiro como analista e planejador
+- depois como executor em issues de escopo estrito
+- registrar cada rodada importante
+- so avancar para execucao estrutural apos alinhamento do board e do PR pendente
+
+---
+
+## Conclusao
+
+O melhor uso do Codex no ShowTrials nao e como "gerador de codigo", mas como:
+
+- assistente de leitura profunda
+- parceiro de decisao tecnica
+- executor disciplinado
+- mantenedor de rastreabilidade
+
+Se essa disciplina for mantida, o Codex pode acelerar bastante o projeto sem comprometer a coerencia arquitetural que ja e um dos seus pontos mais fortes.


### PR DESCRIPTION
## Escopo
- adiciona o manual de colaboracao com o Codex
- adiciona o template de rodada
- adiciona as rodadas documentadas de 22/03/2026 e 23/03/2026

## Objetivo
Tornar oficial no repositório a documentação operacional da colaboração Codex + projeto, em alinhamento com a governança e com o método de documentação por rodadas.